### PR TITLE
reshaping an OffsetArray reshapes the parent

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -64,6 +64,7 @@ Base.similar(f::Union{Function,DataType}, shape::Tuple{UnitRange,Vararg{UnitRang
 
 Base.reshape(A::AbstractArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) = OffsetArray(reshape(A, map(length, inds)), map(indexoffset, inds))
 
+Base.reshape(A::OffsetArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) = OffsetArray(reshape(parent(A), map(length, inds)), map(indexoffset, inds))
 # Don't allow bounds-checks to be removed during Julia 0.5
 @inline function Base.getindex{T,N}(A::OffsetArray{T,N}, I::Vararg{Int,N})
     checkbounds(A, I...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,7 +98,6 @@ for (a,d) in zip(A, A0)
     @test a == d
 end
 
-
 # show
 io = IOBuffer()
 show(io, A)
@@ -143,6 +142,20 @@ B = similar(A, (-3:3,1:4))
 B = similar(parent(A), (-3:3,1:4))
 @test isa(B, OffsetArray{Int,2})
 @test indices(B) === (-3:3, 1:4)
+
+# Reshape
+B = reshape(A0, -10:-9, 9:10)
+@test isa(B, OffsetArray{Int,2})
+@test parent(B) === A0
+@test indices(B) == (-10:-9, 9:10)
+B = reshape(A, -10:-9, 9:10)
+@test isa(B, OffsetArray{Int,2})
+@test parent(B) === A0
+@test indices(B) == (-10:-9, 9:10)
+b = reshape(A, -7:-4)
+@test indices(b) == (-7:-4,)
+@test isa(parent(b), Vector{Int})
+@test parent(b) == A0[:]
 
 # Indexing with OffsetArray indices
 i1 = OffsetArray([2,1], (-5,))


### PR DESCRIPTION
When reshaping there's no need to keep the original OffsetArray container, it's possible this fixes a bug (I can't remember, I've had this for several days now).