### PR TITLE
Turn on precompilation, error testing in constructor, and a reshape fix

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -72,6 +72,11 @@ Base.similar(f::Union{Function,DataType}, shape::Tuple{UnitRange,Vararg{UnitRang
 Base.reshape(A::AbstractArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) = OffsetArray(reshape(A, map(length, inds)), map(indexoffset, inds))
 
 Base.reshape(A::OffsetArray, inds::Tuple{UnitRange,Vararg{UnitRange}}) = OffsetArray(reshape(parent(A), map(length, inds)), map(indexoffset, inds))
+
+function Base.reshape(A::OffsetArray, inds::Tuple{UnitRange,Vararg{Union{UnitRange,Int,Base.OneTo}}})
+    throw(ArgumentError("reshape must supply UnitRange indices, got $(typeof(inds)).\n       Note that reshape(A, Val{N}) is not supported for OffsetArrays."))
+end
+
 # Don't allow bounds-checks to be removed during Julia 0.5
 @inline function Base.getindex{T,N}(A::OffsetArray{T,N}, I::Vararg{Int,N})
     checkbounds(A, I...)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -29,8 +29,12 @@ OffsetArray{T,N}(::Type{T}, inds::Vararg{UnitRange{Int},N}) = OffsetArray{T,N}(i
 # second method should not be necessary.
 OffsetArray{T}(A::AbstractArray{T,0}, inds::Tuple{}) = OffsetArray{T,0,typeof(A)}(A, ())
 OffsetArray{T,N}(A::AbstractArray{T,N}, inds::Tuple{}) = error("this should never be called")
-OffsetArray{T,N}(A::AbstractArray{T,N}, inds::NTuple{N,AbstractUnitRange}) =
+function OffsetArray{T,N}(A::AbstractArray{T,N}, inds::NTuple{N,AbstractUnitRange})
+    lA = map(length, indices(A))
+    lI = map(length, inds)
+    lA == lI || throw(DimensionMismatch("supplied indices do not agree with the size of the array (got size $lA for the array and $lI for the indices"))
     OffsetArray(A, map(indexoffset, inds))
+end
 OffsetArray{T,N}(A::AbstractArray{T,N}, inds::Vararg{AbstractUnitRange,N}) =
     OffsetArray(A, inds)
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module OffsetArrays
 
 Base.@deprecate_binding (..) Colon()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,9 @@ b = reshape(A, -7:-4)
 @test indices(b) == (-7:-4,)
 @test isa(parent(b), Vector{Int})
 @test parent(b) == A0[:]
+a = OffsetArray(rand(3,3,3), -1:1, 0:2, 3:5)
+@test_throws ArgumentError reshape(a, Val{2})
+@test_throws ArgumentError reshape(a, Val{4})
 
 # Indexing with OffsetArray indices
 i1 = OffsetArray([2,1], (-5,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,9 @@ S = OffsetArray(view(A0, 1:2, 1:2), (-1,2))   # LinearSlow
 @test indices(A) == indices(S) == (0:1, 3:4)
 @test_throws ErrorException size(A)
 @test_throws ErrorException size(A, 1)
+@test A == OffsetArray(A0, 0:1, 3:4)
+@test_throws DimensionMismatch OffsetArray(A0, 0:2, 3:4)
+@test_throws DimensionMismatch OffsetArray(A0, 0:1, 2:4)
 
 # Scalar indexing
 @test A[0,3] == A[1] == S[0,3] == S[1] == 1


### PR DESCRIPTION
This is a bit of a grab bag of things I've noticed in recent usage. Besides turning on precompilation, all the changes result in the throwing of errors when the inputs don't make sense.

Ref https://github.com/JuliaLang/julia/pull/18160, which may or may not need to be merged before this passes tests (I don't think it will, but we'll find out soon enough).
