### PR TITLE
Faster benchmarks

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,17 +6,13 @@ const dim = 1000
 x = Array(Float64, 2*dim)
 y = OffsetArray(Float64, -dim + 1 : dim)
 
-fillx() = for i = 1:2*dim x[i] = i end
-filly() = for i = -dim+1:dim y[i] = i end
-updatex() = for i = 1:2*dim x[i] = x[i] + i end
-updatey() = for i = -dim+1:dim y[i] = y[i] + i end
-updatex_eachindex() = for i in eachindex(x) x[i] = x[i] + i end
-updatey_eachindex() = for i in eachindex(y) y[i] = y[i] + i end
+fillx(x) = for i in indices(x,1); x[i] = i; end
+updatex(x) = for i in indices(x,1); x[i] = x[i] + i; end
+updatex_eachindex(x) = for i in eachindex(x); x[i] = x[i] + i; end
 
-@benchmark fillx()
-@benchmark filly()
-@benchmark updatex()
-@benchmark updatey()
-@benchmark updatex_eachindex()
-@benchmark updatey_eachindex()
-
+@show @benchmark fillx(x)
+@show @benchmark fillx(y)
+@show @benchmark updatex(x)
+@show @benchmark updatex(y)
+@show @benchmark updatex_eachindex(x)
+@show @benchmark updatex_eachindex(y)

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -59,10 +59,10 @@ Base.eachindex(::LinearFast, A::OffsetVector) = indices(A, 1)
 _indices(::Tuple{}, ::Tuple{}) = ()
 Base.indices1{T}(A::OffsetArray{T,0}) = 1:1  # we only need to specialize this one
 
-function Base.similar(A::OffsetArray, T::Type, dims::Dims)
+function Base.similar{T}(A::OffsetArray, ::Type{T}, dims::Dims)
     B = similar(parent(A), T, dims)
 end
-function Base.similar(A::AbstractArray, T::Type, inds::Tuple{UnitRange,Vararg{UnitRange}})
+function Base.similar{T}(A::AbstractArray, ::Type{T}, inds::Tuple{UnitRange,Vararg{UnitRange}})
     B = similar(A, T, map(length, inds))
     OffsetArray(B, map(indexoffset, inds))
 end


### PR DESCRIPTION
Thanks for adding the benchmarks! I noticed I could make them even faster (in some cases, from ~300microseconds down to ~4microseconds) by getting rid of the global variables.

It's satisfying that we're fairly close to the performance of `Array`s. One of the things to note is that these benchmarks don't use `@inbounds`; if they did, this would look worse. For Julia 0.6, we'll be able to elide bounds checking and catch up, but that's too dangerous for 0.5 (it would generate a lot of segfaults when used in other packages that haven't been updated for non-1 indexing).

I also made `similar` a little faster; that doesn't have anything to do with these benchmarks, though.
