### PR TITLE
Add unsafe macro to eliminate bounds checking

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,9 +9,9 @@ x2d = Array(Float64, 2*dim, 2*dim)
 y2d = OffsetArray(Float64, -dim + 1 : dim, -dim + 1 : dim)
 
 fill(x) = for i in indices(x,1); x[i] = i; end
-fill2d(x) = for i in indices(x,1); for j in indices(x,2); x[i,j] = i + j; end; end
+fill2d(x) = for j in indices(x,2); for i in indices(x,1); x[i,j] = i + j; end; end
 update(x) = for i in indices(x,1); x[i] = x[i] + i; end
-update2d(x) = for i in indices(x,1); for j in indices(x,2); x[i,j] = x[i,j] + i + j; end; end
+update2d(x) = for j in indices(x,2); for i in indices(x,1); x[i,j] = x[i,j] + i + j; end; end
 update_eachindex(x) = for i in eachindex(x); x[i] = x[i] + i; end
 
 @show @benchmark fill(x)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -14,6 +14,12 @@ update(x) = for i in indices(x,1); x[i] = x[i] + i; end
 update2d(x) = for j in indices(x,2); for i in indices(x,1); x[i,j] = x[i,j] + i + j; end; end
 update_eachindex(x) = for i in eachindex(x); x[i] = x[i] + i; end
 
+unsafe_fill(x) = @unsafe(for i in indices(x,1); x[i] = i; end)
+unsafe_fill2d(x) = @unsafe(for j in indices(x,2); for i in indices(x,1); x[i,j] = i + j; end; end)
+unsafe_update(x) = @unsafe(for i in indices(x,1); x[i] = x[i] + i; end)
+unsafe_update2d(x) = @unsafe(for j in indices(x,2); for i in indices(x,1); x[i,j] = x[i,j] + i + j; end; end)
+unsafe_update_eachindex(x) = @unsafe(for i in eachindex(x); x[i] = x[i] + i; end)
+
 @show @benchmark fill(x)
 @show @benchmark fill(y)
 @show @benchmark fill2d(x2d)
@@ -24,3 +30,14 @@ update_eachindex(x) = for i in eachindex(x); x[i] = x[i] + i; end
 @show @benchmark update2d(y2d)
 @show @benchmark update_eachindex(x)
 @show @benchmark update_eachindex(y)
+
+@show @benchmark unsafe_fill(x)
+@show @benchmark unsafe_fill(y)
+@show @benchmark unsafe_fill2d(x2d)
+@show @benchmark unsafe_fill2d(y2d)
+@show @benchmark unsafe_update(x)
+@show @benchmark unsafe_update(y)
+@show @benchmark unsafe_update2d(x2d)
+@show @benchmark unsafe_update2d(y2d)
+@show @benchmark unsafe_update_eachindex(x)
+@show @benchmark unsafe_update_eachindex(y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,3 +323,19 @@ B = ones(1:3, -1:1)
 B = fill(5, 1:3, -1:1)
 @test indices(B) == (1:3,-1:1)
 @test all(B.==5)
+
+# @unsafe
+a = OffsetArray(zeros(7), -3:3)
+unsafe_fill!(x) = @unsafe(for i in indices(x,1); x[i] = i; end)
+function unsafe_sum(x)
+    s = zero(eltype(x))
+    @unsafe for i in indices(x,1)
+        s += x[i]
+    end
+    s
+end
+unsafe_fill!(a)
+for i = -3:3
+    @test a[i] == i
+end
+@test unsafe_sum(a) == 0


### PR DESCRIPTION
This PR deserves careful thought, and it's possible we shouldn't merge it. We've made a deliberate decision to recommend against making `@inbounds` work with arrays like OffsetArrays, because there's too much code in the wild that has marked sections of code with `@inbounds` for which it isn't actually safe unless the indices start at 1.

However, in practical usage the lack of bounds-check elimination can be a big deal; in our `update2d` benchmark, there's about a 3-fold performance gap between OffsetArrays and Arrays. In applications like [ImagesFiltering.jl](https://github.com/JuliaImages/ImagesFiltering.jl/tree/teh/finish2) where I'm making extensive use of OffsetArrays, this is noticeable enough that I found myself starting to write special implementations for OffsetArrays that stripped off the container; after a while I realized that was stupid and did this instead.

The hack here is to use a different name, here called `@unsafe`, which accomplishes something similar to `@inbounds` (in a much less sophisticated/powerful way, but good enough for quite a few cases). The point being that since there isn't any code out there already using `@unsafe`, perhaps this is OK. In the new benchmarks using `@unsafe`, OffsetArrays match the performance of Arrays.

Thoughts? CC @JeffBezanson to give him the chance to disagree.
