### PR TITLE
Avoid throwing depwarn for zeros/ones methods defined in Base

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -159,9 +159,9 @@ end
 
 # Deprecations
 import Base: zeros, ones
-@deprecate zeros(T::Type, inds::UnitRange...) fill!(OffsetArray{T}(inds), zero(T))
-@deprecate  ones(T::Type, inds::UnitRange...) fill!(OffsetArray{T}(inds), one(T))
-@deprecate zeros(inds::UnitRange...) fill!(OffsetArray{Float64}(inds), 0)
-@deprecate  ones(inds::UnitRange...) fill!(OffsetArray{Float64}(inds), 1)
+@deprecate zeros(T::Type, ind1::UnitRange, ind2::UnitRange, inds::UnitRange...) fill!(OffsetArray{T}((ind1, ind2, inds...)), zero(T))
+@deprecate  ones(T::Type, ind1::UnitRange, inds2::UnitRange, inds::UnitRange...) fill!(OffsetArray{T}((ind1, ind2, inds...)), one(T))
+@deprecate zeros(ind1::UnitRange, ind2::UnitRange, inds::UnitRange...) fill!(OffsetArray{Float64}((ind1, ind2, inds...)), 0)
+@deprecate  ones(ind1::UnitRange, ind2::UnitRange, inds::UnitRange...) fill!(OffsetArray{Float64}((ind1, ind2, inds...)), 1)
 
 end # module


### PR DESCRIPTION
These improve upon the deprecations added in #12, which are inadvertently triggered even for syntax classically supported by Base:

```jl
julia> zeros(1:5)
WARNING: zeros(inds::UnitRange...) is deprecated, use fill!(OffsetArray{Float64}(inds),0) instead.
 in depwarn(::String, ::Symbol) at deprecated.jl:64
 in zeros(::UnitRange{Int64}) at deprecated.jl:50
 in eval(::Module, ::Any) at boot.jl:234
 in eval_user_input(::Any, ::Base.REPL.REPLBackend) at REPL.jl:64
 in macro expansion at REPL.jl:95 [inlined]
 in (::Base.REPL.##3#4{Base.REPL.REPLBackend})() at event.jl:68
while loading no file, in expression starting on line 0
OffsetArrays.OffsetArray{Float64,1,Array{Float64,1}} with indices 1:5:
 0.0
 0.0
 0.0
 0.0
 0.0
```
