### PR TITLE
Support atsign-unsafe indexing with trailing 1s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - linux
 
 julia:
+    - 0.5
     - nightly
 
 notifications:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,12 +39,25 @@ S = OffsetArray(view(A0, 1:2, 1:2), (-1,2))   # LinearSlow
 @test_throws DimensionMismatch OffsetArray(A0, 0:1, 2:4)
 
 # Scalar indexing
-@test A[0,3] == A[1] == S[0,3] == S[1] == 1
-@test A[1,3] == A[2] == S[1,3] == S[2] == 2
-@test A[0,4] == A[3] == S[0,4] == S[3] == 3
-@test A[1,4] == A[4] == S[1,4] == S[4] == 4
+@test A[0,3] == A[0,3,1] == A[1] == S[0,3] == S[0,3,1] == S[1] == 1
+@test A[1,3] == A[1,3,1] == A[2] == S[1,3] == S[1,3,1] == S[2] == 2
+@test A[0,4] == A[0,4,1] == A[3] == S[0,4] == S[0,4,1] == S[3] == 3
+@test A[1,4] == A[1,4,1] == A[4] == S[1,4] == S[1,4,1] == S[4] == 4
+@test @unsafe(A[0,3]) == @unsafe(A[0,3,1]) == @unsafe(A[1]) == @unsafe(S[0,3]) == @unsafe(S[0,3,1]) == @unsafe(S[1]) == 1
+@test @unsafe(A[1,3]) == @unsafe(A[1,3,1]) == @unsafe(A[2]) == @unsafe(S[1,3]) == @unsafe(S[1,3,1]) == @unsafe(S[2]) == 2
+@test @unsafe(A[0,4]) == @unsafe(A[0,4,1]) == @unsafe(A[3]) == @unsafe(S[0,4]) == @unsafe(S[0,4,1]) == @unsafe(S[3]) == 3
+@test @unsafe(A[1,4]) == @unsafe(A[1,4,1]) == @unsafe(A[4]) == @unsafe(S[1,4]) == @unsafe(S[1,4,1]) == @unsafe(S[4]) == 4
 @test_throws BoundsError A[1,1]
 @test_throws BoundsError S[1,1]
+@test_throws BoundsError A[0,3,2]
+@test_throws BoundsError A[0,3,0]
+Ac = copy(A)
+Ac[0,3] = 10
+@test Ac[0,3] == 10
+Ac[0,3,1] = 11
+@test Ac[0,3] == 11
+@unsafe Ac[0,3,1] = 12
+@test Ac[0,3] == 12
 
 # Vector indexing
 @test A[:, 3] == S[:, 3] == OffsetArray([1,2], (A.offsets[1],))
@@ -63,8 +76,15 @@ S = OffsetArray(view(A0, 1:2, 1:2), (-1,2))   # LinearSlow
 
 # CartesianIndexing
 @test A[CartesianIndex((0,3))] == S[CartesianIndex((0,3))] == 1
+@test A[CartesianIndex((0,3)),1] == S[CartesianIndex((0,3)),1] == 1
+@test @unsafe(A[CartesianIndex((0,3))]) == @unsafe(S[CartesianIndex((0,3))]) == 1
+@test @unsafe(A[CartesianIndex((0,3)),1]) == @unsafe(S[CartesianIndex((0,3)),1]) == 1
 @test_throws BoundsError A[CartesianIndex(1,1)]
+@test_throws BoundsError A[CartesianIndex(1,1),0]
+@test_throws BoundsError A[CartesianIndex(1,1),2]
 @test_throws BoundsError S[CartesianIndex(1,1)]
+@test_throws BoundsError S[CartesianIndex(1,1),0]
+@test_throws BoundsError S[CartesianIndex(1,1),2]
 @test eachindex(A) == 1:4
 @test eachindex(S) == CartesianRange((0:1,3:4))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using Base.Test
 using OffsetArrays
 
-@test isempty(detect_ambiguities(OffsetArrays, Base, Core))
+ambs = detect_ambiguities(Base, Core)  # in case these have ambiguities of their own
+@test isempty(setdiff(detect_ambiguities(OffsetArrays, Base, Core), ambs))
 
 # Basics
 for n = 0:5


### PR DESCRIPTION
Wrapping certain indexing operations in `@unsafe` led to errors, which this fixes (and tests). It incidentally optimizes linear indexing in conjunction with `@unsafe`.
