### PR TITLE
Fix unnecessary nested `OffsetArray`

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -73,8 +73,8 @@ OffsetArray(A::AbstractArray{T,N}, inds::Vararg{AbstractUnitRange,N}) where {T,N
     OffsetArray(A, inds)
 
 # avoid a level of indirection when nesting OffsetArrays
-function OffsetArray(A::OffsetArray, inds::NTuple{N,AbstractUnitRange}) where {N}
-    OffsetArray(parent(A), inds)
+function OffsetArray(A::OffsetArray, offsets::NTuple{N,Int}) where {N}
+    OffsetArray(parent(A), offsets .+ A.offsets)
 end
 OffsetArray(A::OffsetArray{T,0}, inds::Tuple{}) where {T} = OffsetArray(parent(A), ())
 # OffsetArray(A::OffsetArray{T,N}, inds::Tuple{}) where {T,N} = error("this should never be called")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,6 +124,23 @@ end
     @test axes(y) == (r,)
 end
 
+@testset "OffsetArray of OffsetArray construction" begin
+    # guarantee no unnecessary nesting of `OffsetArray`s
+    r = -2:5
+    d = collect(r)
+    y = OffsetArray(d, r)
+
+    # range constructor
+    y0 = OffsetArray(y, 0:7)
+    @test y0[0] == r[1]
+    @test typeof(parent(y0)) <: Array
+
+    # offset constructor
+    y1 = OffsetArray(y, +2)
+    @test y1[0] == r[1]
+    @test typeof(parent(y1)) <: Array
+end
+
 @testset "Axes supplied to constructor correspond to final result" begin
     # Ref https://github.com/JuliaArrays/OffsetArrays.jl/pull/65#issuecomment-457181268
     B = BidirectionalVector([1, 2, 3], -2)


### PR DESCRIPTION
Before this PR, `y1` is`OffsetArray(OffsetArray(...`

```julia
y = OffsetArray(-2:5, -2:5)
y1 = OffsetArray(y, +2)
```

Since the representation of `OffsetArray` just the parent and the offsets, I thought it makes most sense to define this un-nesting at that "base" level. Then any other constructor, e.g. using ranges, benefits.
