### PR TITLE
properly handle colon in offset reshape

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -9,15 +9,15 @@ end
 
 export OffsetArray, OffsetMatrix, OffsetVector
 
-include("axes.jl")
-include("utils.jl")
-include("origin.jl")
-
 # Technically we know the length of CartesianIndices but we need to convert it first, so here we
 # don't put it in OffsetAxisKnownLength.
 const OffsetAxisKnownLength = Union{Integer, AbstractUnitRange}
 const OffsetAxis = Union{OffsetAxisKnownLength, Colon}
 const ArrayInitializer = Union{UndefInitializer, Missing, Nothing}
+
+include("axes.jl")
+include("utils.jl")
+include("origin.jl")
 
 ## OffsetArray
 """
@@ -280,13 +280,15 @@ end
 Base.reshape(A::AbstractArray, inds::OffsetAxis...) = reshape(A, inds)
 function Base.reshape(A::AbstractArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}})
     AR = reshape(A, map(_indexlength, inds))
-    return OffsetArray(AR, map(_offset, axes(AR), inds))
+    return OffsetArray(AR, _offset_reshape_uncolon(A, inds))
 end
 
 # Reshaping OffsetArrays can "pop" the original OffsetArray wrapper and return
 # an OffsetArray(reshape(...)) instead of an OffsetArray(reshape(OffsetArray(...)))
-Base.reshape(A::OffsetArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}}) =
-    OffsetArray(reshape(parent(A), map(_indexlength, inds)), map(_indexoffset, inds))
+function Base.reshape(A::OffsetArray, inds::Tuple{OffsetAxis,Vararg{OffsetAxis}})
+    AR = reshape(parent(A), map(_indexlength, inds))
+    OffsetArray(AR, _offset_reshape_uncolon(A, inds))
+end
 # And for non-offset axes, we can just return a reshape of the parent directly
 Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) = reshape(parent(A), inds)
 Base.reshape(A::OffsetArray, inds::Dims) = reshape(parent(A), inds)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -17,21 +17,27 @@ function _offset_reshape_uncolon(A::AbstractArray, I::Tuple{OffsetAxis,Vararg{Of
     @noinline throw2(A, I) = throw(DimensionMismatch(string("array size $(length(A)) ",
         "must be divisible by the product of the new dimensions $I")))
 
-    pre = Base._before_colon(I...)
-    post = Base._after_colon(I...)
-    Base._any_colon(post...) && throw1(dims)
+    pre = _before_colon(I...)
+    post = _after_colon(I...)
+    _any_colon(post...) && throw1(dims)
     nprev = isempty(pre) ? 1 : mapreduce(_length, *, pre)
     npost = isempty(post) ? 1 : mapreduce(_length, *, post)
     sz, remainder = divrem(length(A), nprev * npost)
     remainder == 0 || throw2(A, dims)
 
+    # preserve the offset information, the default offset beyond `ndims(A)` is 0
     n = length(pre)
     r = Base.OneTo(Int(sz))
-    # preserve the offset information
     Δ = n < ndims(A) ? _offset(axes(A, n+1), r) : 0
     (pre..., IdOffsetRange(r, -Δ), post...)
 end
-
+@inline _any_colon() = false
+@inline _any_colon(r::Colon, tail...) = true
+@inline _any_colon(r::Any, tail...) = _any_colon(tail...)
+@inline _before_colon(r::Any, tail...) = (r, _before_colon(tail...)...)
+@inline _before_colon(r::Colon, tail...) = ()
+@inline _after_colon(r::Any, tail...) =  _after_colon(tail...)
+@inline _after_colon(r::Colon, tail...) = tail
 @inline _length(r::AbstractUnitRange) = length(r)
 @inline _length(n::Int) = n
 


### PR DESCRIPTION
As a placeholder for a slice, `Colon` at the k-th position also preserves the offset of the `axes(A, k)`. The default offset for `k>=ndims(A)` is assumed to be 0.

The implementation is based on https://github.com/JuliaLang/julia/blob/d29126a43ee289fc5ab8fcb3dc0e03f514605950/base/reshapedarray.jl#L119-L137

closes #220

cc: @jishnub 