### PR TITLE
WIP: enhance `parent_call`

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -7,5 +7,7 @@ OffsetMatrix
 OffsetArrays.Origin
 OffsetArrays.IdOffsetRange
 OffsetArrays.no_offset_view
+OffsetArrays.centered
+OffsetArrays.center
 OffsetArrays.AxisConversionStyle
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -9,5 +9,6 @@ OffsetArrays.IdOffsetRange
 OffsetArrays.no_offset_view
 OffsetArrays.centered
 OffsetArrays.center
+OffsetArrays.no_offset_view_apply
 OffsetArrays.AxisConversionStyle
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -864,7 +864,7 @@ end
 @testset "unwrap" begin
     for A in [ones(2, 2), ones(2:3, 2:3), ZeroBasedRange(1:4)]
         p, f = OffsetArrays.unwrap(A)
-        @test f(map(y -> y^2, p)) == A.^2
+        @test f(map(y -> y^2, p...)) == A.^2
     end
 end
 


### PR DESCRIPTION
- rename it to `no_offset_view_apply` as a part of the non-exported API.
- allow multiple inputs

I find this pattern used very widely when dealing with `CUDA.CuArray`, 

```julia
julia> A = OffsetArray(CUDA.rand(4, 4), -1, -1);

julia> B = OffsetArray(CUDA.rand(4, 4), -1, -1);

julia> A .- B
ERROR: Scalar indexing is disallowed.

julia> no_offset_view_apply(A, B) do x, y
    x .- y
end # 🎉 
4×4 OffsetArray(::CuArray{Float32, 2}, 0:3, 0:3) with eltype Float32 with indices 0:3×0:3:
```

A lot of seemingly ambiguous operations can be supported by this, e.g., #93, #137