### PR TITLE
propagate first and last for OffsetRanges

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -456,7 +456,9 @@ Broadcast.broadcast_unalias(dest::OffsetArray, src::OffsetArray) = parent(dest) 
 const OffsetRange{T} = OffsetVector{T,<:AbstractRange{T}}
 const OffsetUnitRange{T} = OffsetVector{T,<:AbstractUnitRange{T}}
 
-Base.step(a::OffsetRange) = step(parent(a))
+for f in [:first, :last, :step]
+    @eval Base.$f(a::OffsetRange) = $f(parent(a))
+end
 
 Base.checkindex(::Type{Bool}, inds::AbstractUnitRange, or::OffsetRange) = Base.checkindex(Bool, inds, parent(or))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1492,6 +1492,14 @@ end
             @test a == d
         end
     end
+
+    # Special methods for an OffsetRange
+    for r in Any[3:10, 3:1:10, UnitRange(3.0, 10.0), 3.0:1.0:10.0]
+        ro = OffsetArray(r)
+        @test first(ro) == first(r)
+        @test last(ro) == last(r)
+        @test step(ro) == step(r)
+    end
 end
 
 @testset "show/summary" begin


### PR DESCRIPTION
Propagate `first` and `last` to the parent for `OffsetArray(::AbstractRange)`. On master `step` was propagated anyway as this is not defined for abstractarrays in general. The current change is an optimization as it gets around the need to index into the array to find the first element.

The `first` and `last` elements for ranges are often obtained by explicitly accessing fields, so I don't think that it's possible to obtain these for wrapper types by using traits.

I'm not sure if this provides an immediate real-world performance benefit, so perhaps we may leave this open for now. I had created this keeping something like https://github.com/JuliaLang/julia/issues/41945 in mind. If `iterate` uses traits then we may require a rapid evaluation of `first` and `last` elements for `OffsetRange`s to be as performant as ranges.