### PR TITLE
type assertion in convert

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OffsetArrays"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.12.8"
+version = "1.13.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -253,7 +253,7 @@ end
 end
 @inline OffsetArray{T,N,A}(M::A; checkoverflow = false) where {T,N,A<:AbstractArray{T,N}} = OffsetArray{T,N,A}(M, ntuple(zero, Val(N)); checkoverflow = checkoverflow)
 
-Base.convert(::Type{T}, M::AbstractArray) where {T<:OffsetArray} = M isa T ? M : T(M)
+Base.convert(::Type{T}, M::AbstractArray) where {T<:OffsetArray} = M isa T ? M : T(M)::T
 
 @inline AbstractArray{T,N}(M::OffsetArray{S,N}) where {T,S,N} = OffsetArray{T}(M)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -920,6 +920,12 @@ Base.Int(a::WeirdInteger) = a
             end
         end
     end
+
+    @testset "convert" begin
+        m = zeros(1,1)
+        mo = @inferred (x -> convert(OffsetArray{Float64,2,Matrix{Float64}}, x[1]))(Any[m])
+        @test mo == m
+    end
 end
 
 @testset "Axes supplied to constructor correspond to final result" begin


### PR DESCRIPTION
Since something similar is implemented on Julia nightly now, it seems to be the preferred way forward. After this, the following is inferred:
```julia
julia> @inferred (x -> convert(OffsetArray{Float64,2,Matrix{Float64}}, x[1]))(Any[zeros(1,1)])
1×1 OffsetArray(::Matrix{Float64}, 1:1, 1:1) with eltype Float64 with indices 1:1×1:1:
 0.0
```
This may help with inference downstream. Mildly breaking if `T(x)` doesn't return an object of type `T`, but then the conversion fails anyway, so this may be considered a bug. It's better to error if the conversion fails.