### PR TITLE
Add `isonebased` trait to opt out of `OffsetArray` wrappers

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using EllipsisNotation
 using FillArrays
 using LinearAlgebra
 using OffsetArrays
-using OffsetArrays: IdentityUnitRange, no_offset_view, IIUR, Origin, IdOffsetRange
+using OffsetArrays: IdentityUnitRange, no_offset_view, IIUR, Origin, IdOffsetRange, isonebased
 using StaticArrays
 using Test
 
@@ -2261,6 +2261,14 @@ Base.parent(x::PointlessWrapper) = x.parent
 Base.size(x::PointlessWrapper) = size(parent(x))
 Base.axes(x::PointlessWrapper) = axes(parent(x))
 Base.getindex(x::PointlessWrapper, i...) = x.parent[i...]
+
+@testset "isonebased" begin
+    @test isonebased(Base.OneTo(2))
+    @test !isonebased(1:2)
+    @test isonebased(IdentityUnitRange(Base.OneTo(2)))
+    @test !isonebased(IdentityUnitRange(1:2))
+    @test similar(zeros(1), Int, IdentityUnitRange(Base.OneTo(2))) isa Vector{Int}
+end
 
 @testset "no offset view" begin
     # OffsetArray fallback


### PR DESCRIPTION
The idea is
```julia
julia> OffsetArrays.no_offset_view(SMatrix{2,2}(1:4))
2×2 OffsetArray(::SMatrix{2, 2, Int64, 4}, 1:2, 1:2) with eltype Int64 with indices 1:2×1:2:
 1  3
 2  4

julia> OffsetArrays.isonebased(::SOneTo) = true

julia> OffsetArrays.no_offset_view(SMatrix{2,2}(1:4)) # no wrapper anymore
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  3
 2  4
```
Also, in this case, the `similar` method in this package will forward the lengths of the axes to `Base`, so the result will usually be an `Array` instead of an `OffsetArray`:
```julia
julia> similar(rand(2), Int, Base.IdentityUnitRange(Base.OneTo(2)))
2-element Vector{Int64}:
              -1
 140522905523888
```