### PR TITLE
Trying to allow `Int8` as indices

### DIFF
--- a/ext/OffsetArraysAdaptExt.jl
+++ b/ext/OffsetArraysAdaptExt.jl
@@ -10,6 +10,7 @@ Adapt.adapt_structure(to, O::OffsetArray) = OffsetArrays.parent_call(x -> Adapt.
 
 @static if isdefined(Adapt, :parent_type)
     # To support Adapt 3.0 which doesn't have parent_type defined
+    Adapt.parent_type(::Type{OffsetArray{T,N,AA,I}}) where {T,N,AA,I} = AA
     Adapt.parent_type(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
     Adapt.unwrap_type(W::Type{<:OffsetArray}) = unwrap_type(parent_type(W))
 end

--- a/ext/OffsetArraysAdaptExt.jl
+++ b/ext/OffsetArraysAdaptExt.jl
@@ -11,7 +11,6 @@ Adapt.adapt_structure(to, O::OffsetArray) = OffsetArrays.parent_call(x -> Adapt.
 @static if isdefined(Adapt, :parent_type)
     # To support Adapt 3.0 which doesn't have parent_type defined
     Adapt.parent_type(::Type{OffsetArray{T,N,AA,I}}) where {T,N,AA,I} = AA
-    Adapt.parent_type(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
     Adapt.unwrap_type(W::Type{<:OffsetArray}) = unwrap_type(parent_type(W))
 end
 

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -183,9 +183,6 @@ for FT in (:OffsetArray, :OffsetVector, :OffsetMatrix)
         I = map(+, _offsets(A, parent(A)), offsets)
         $FT(parent(A), I, checkoverflow = false)
     end
-    @eval @inline function $FT(A::OffsetArray, offsets::Tuple{Integer,Vararg{Integer}}; kw...)
-        $FT(A, map(Int, offsets); kw...)
-    end
 
     # In general, indices get converted to AbstractUnitRanges.
     # CartesianIndices{N} get converted to N ranges
@@ -230,9 +227,6 @@ end
     MvA = convert(A, Mv)::A
     Iof = map(+, _offsets(M), I)
     OffsetArray{T,N,A}(MvA, Iof, checkoverflow = false)
-end
-@inline function OffsetArray{T, N, AA}(parent::AbstractArray{<:Any,N}, offsets::NTuple{N,Integer}; kw...) where {T, N, AA<:AbstractArray{T,N}}
-    OffsetArray{T, N, AA}(parent, offsets; kw...)
 end
 @inline function OffsetArray{T,N,A}(M::AbstractArray{<:Any,N}, I::Tuple{AbstractUnitRange,Vararg{AbstractUnitRange}}; kw...) where {T,N,A<:AbstractArray{T,N}}
     _checkindices(M, I, "indices")
@@ -327,13 +321,11 @@ function Base.similar(A::AbstractArray, ::Type{T}, shape::Tuple{OffsetAxisKnownL
     P = _similar_axes_or_length(A, T, new_shape, shape)
     return OffsetArray(P, map(_offset, axes(P), shape))
 end
-Base.similar(::Type{A}, sz::Tuple{Vararg{Integer}}) where {A<:OffsetArray} = similar(Array{eltype(A)}, sz)
 function Base.similar(::Type{T}, shape::Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}) where {T<:AbstractArray}
     new_shape = map(_strip_IdOffsetRange, shape)
     P = _similar_axes_or_length(T, new_shape, shape)
     OffsetArray(P, map(_offset, axes(P), shape))
 end
-similar(::Type{A}, sz::Tuple{Integer,Vararg{Integer}}) where {A<:OffsetArray} = similar(Array{eltype(A)}, sz)
 
 # Try to use the axes to generate the parent array type
 # This is useful if the axes have special meanings, such as with static arrays

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -135,7 +135,7 @@ _offset_eltype(::Tuple{}) = Int
 end
 # Special case for 0-dimensional arrays with 3-param call
 @inline function OffsetArray{T, N, AA}(parent::AA, offsets::Tuple{}; checkoverflow=true) where {T, N, AA<:AbstractArray{T,0}}
-    OffsetArray{T, N, AA, Int}(parent, offsets; checkoverflow=checkoverflow)
+    OffsetArray{T, N, AA, _offset_eltype(offsets)}(parent, offsets; checkoverflow=checkoverflow)
 end
 
 """

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -436,19 +436,19 @@ end
 end
 @propagate_inbounds Base.getindex(A::OffsetArray, i::Int)  = parent(A)[i]
 
-@inline function Base.setindex!(A::OffsetArray{T,N,AA,<:Any}, val, I::Vararg{Integer,N}) where {T,N,AA}
+@inline function Base.setindex!(A::OffsetArray{T,N,AA,<:Any}, val, I::Vararg{Int,N}) where {T,N,AA}
     @boundscheck checkbounds(A, I...)
     J = map(parentindex, axes(A), I)
     @inbounds parent(A)[J...] = val
     A
 end
 
-@inline function Base.setindex!(A::OffsetVector, val, i::Integer)
+@inline function Base.setindex!(A::OffsetVector, val, i::Int)
     @boundscheck checkbounds(A, i)
     @inbounds parent(A)[parentindex(Base.axes1(A), i)] = val
     A
 end
-@propagate_inbounds function Base.setindex!(A::OffsetArray, val, i::Integer)
+@propagate_inbounds function Base.setindex!(A::OffsetArray, val, i::Int)
     parent(A)[i] = val
     A
 end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -415,7 +415,7 @@ parentindex(r::IdOffsetRange, i) = i - r.offset
 
 @propagate_inbounds Base.getindex(A::OffsetArray{<:Any,0})  = A.parent[]
 
-@inline function Base.getindex(A::OffsetArray{<:Any,N}, I::Vararg{Integer,N}) where N
+@inline function Base.getindex(A::OffsetArray{<:Any,N}, I::Vararg{Int,N}) where N
     @boundscheck checkbounds(A, I...)
     J = map(parentindex, axes(A), I)
     @inbounds parent(A)[J...]

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -396,7 +396,8 @@ Base.reshape(A::OffsetArray, inds::Dims) = _reshape_nov(A, inds)
 if VERSION < v"1.10.7"
     # the specialized reshape(parent::AbstractVector, ::Tuple{Colon}) is available in Base at least on this version
     Base.reshape(A::OffsetVector, ::Tuple{Colon}) = A
-    Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Integer,Colon}}}) = _reshape_nov(A, inds)
+    # Keep Int here (not Integer) to avoid method ambiguity with Base on older Julia versions
+    Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = _reshape_nov(A, inds)
 end
 
 # permutedims in Base does not preserve axes, and can not be fixed in a non-breaking way

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -476,7 +476,6 @@ Base.copy(A::OffsetArray) = parent_call(copy, A)
 
 Base.strides(A::OffsetArray) = strides(parent(A))
 Base.elsize(::Type{OffsetArray{T,N,A,I}}) where {T,N,A,I} = Base.elsize(A)
-Base.elsize(::Type{OffsetArray{T,N,A}}) where {T,N,A} = Base.elsize(A)
 Base.cconvert(P::Type{Ptr{T}}, A::OffsetArray{T}) where {T} = Base.cconvert(P, parent(A))
 if VERSION < v"1.11-"
     @inline Base.unsafe_convert(::Type{Ptr{T}}, A::OffsetArray{T}) where {T} = Base.unsafe_convert(Ptr{T}, parent(A))

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -547,7 +547,7 @@ end
 # An OffsetUnitRange{Int} has an equivalent IdOffsetRange with the same values and axes,
 # something similar also holds for OffsetUnitRange{BigInt}
 # We may replace the former with the latter in an indexing operation to obtain a performance boost
-@inline function Base.to_index(r::OffsetUnitRange{<:Union{Integer,BigInt}})
+@inline function Base.to_index(r::OffsetUnitRange{<:Integer})
     of = first(axes(r,1)) - 1
     IdOffsetRange(_subtractoffset(parent(r), of), of)
 end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -289,7 +289,6 @@ end
 
 Base.IndexStyle(::Type{OA}) where {OA<:OffsetArray} = IndexStyle(parenttype(OA))
 parenttype(::Type{OffsetArray{T,N,AA,I}}) where {T,N,AA,I} = AA
-parenttype(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
 parenttype(A::OffsetArray) = parenttype(typeof(A))
 
 Base.parent(A::OffsetArray) = A.parent

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -153,7 +153,7 @@ Type alias and convenience constructor for two-dimensional [`OffsetArray`](@ref)
 const OffsetMatrix{T,AA<:AbstractMatrix{T},I<:Integer} = OffsetArray{T,2,AA,I}
 
 # checks if the offset may be added to the range without overflowing
-function overflow_check(r::AbstractUnitRange, offset::Integer) 
+function overflow_check(r::AbstractUnitRange, offset::Integer)
     Base.hastypemax(eltype(r)) || return nothing
     # This gives some performance boost https://github.com/JuliaLang/julia/issues/33273
     throw_upper_overflow_error(val) = throw(OverflowError("offset should be <= $(typemax(Int) - val) corresponding to the axis $r, received an offset $offset"))
@@ -347,7 +347,6 @@ function Base.similar(::Type{T}, shape::Tuple{OffsetAxisKnownLength,Vararg{Offse
     P = _similar_axes_or_length(T, new_shape, shape)
     OffsetArray(P, map(_offset, axes(P), shape))
 end
-
 # Try to use the axes to generate the parent array type
 # This is useful if the axes have special meanings, such as with static arrays
 # This method is hit if at least one axis provided to similar(A, T, axes) is an IdOffsetRange
@@ -507,7 +506,7 @@ end
 end
 
 # An OffsetUnitRange might use the rapid getindex(::Array, ::AbstractUnitRange{Int}) for contiguous indexing
-@propagate_inbounds function Base.getindex(A::Array, r::OffsetUnitRange{Integer})
+@propagate_inbounds function Base.getindex(A::Array, r::OffsetUnitRange{<:Integer})
     B = A[_contiguousindexingtype(parent(r))]
     OffsetArray(B, axes(r), checkoverflow = false)
 end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -289,6 +289,7 @@ end
 
 Base.IndexStyle(::Type{OA}) where {OA<:OffsetArray} = IndexStyle(parenttype(OA))
 parenttype(::Type{OffsetArray{T,N,AA,I}}) where {T,N,AA,I} = AA
+parenttype(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
 parenttype(A::OffsetArray) = parenttype(typeof(A))
 
 Base.parent(A::OffsetArray) = A.parent

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -104,20 +104,20 @@ end
 _bool_check(::Type, r, offset) = nothing
 
 # Construction/coercion from arbitrary AbstractUnitRanges
-function IdOffsetRange{T,I}(r::AbstractUnitRange, offset::Integer = 0) where {T<:Integer,I<:AbstractUnitRange{T}}
+function IdOffsetRange{T,I}(r::AbstractUnitRange, offset::Integer = Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
     rc, o = offset_coerce(I, r)
     return IdOffsetRange{T,I}(rc, convert(T, o+offset)::T)
 end
-function IdOffsetRange{T}(r::AbstractUnitRange, offset::Integer = 0) where T<:Integer
+function IdOffsetRange{T}(r::AbstractUnitRange, offset::Integer = Int8(0)) where T<:Integer
     rc = convert(AbstractUnitRange{T}, r)::AbstractUnitRange{T}
     return IdOffsetRange{T,typeof(rc)}(rc, convert(T, offset)::T)
 end
-IdOffsetRange(r::AbstractUnitRange{T}, offset::Integer = 0) where T<:Integer =
+IdOffsetRange(r::AbstractUnitRange{T}, offset::Integer = Int8(0)) where T<:Integer =
     IdOffsetRange{T,typeof(r)}(r, convert(T, offset)::T)
 
 # Coercion from other IdOffsetRanges
 IdOffsetRange{T,I}(r::IdOffsetRange{T,I}) where {T<:Integer,I<:AbstractUnitRange{T}} = r
-function IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer = 0) where {T<:Integer,I<:AbstractUnitRange{T}}
+function IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer = Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
     rc, offset_rc = offset_coerce(I, r.parent)
     return IdOffsetRange{T,I}(rc, convert(T, r.offset + offset + offset_rc)::T)
 end
@@ -134,7 +134,7 @@ _subtractindexoffset(values, indices, offset) = _subtractoffset(values, offset)
 function IdOffsetRange(; values::AbstractUnitRange{<:Integer}, indices::AbstractUnitRange{<:Integer})
     length(values) == length(indices) || throw(ArgumentError("values and indices must have the same length"))
     values_nooffset = no_offset_view(values)
-    offset = first(indices) - 1
+    offset = first(indices) - Int8(1)
     values_minus_offset = _subtractindexoffset(values_nooffset, indices, offset)
     return IdOffsetRange(values_minus_offset, offset)
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -104,20 +104,20 @@ end
 _bool_check(::Type, r, offset) = nothing
 
 # Construction/coercion from arbitrary AbstractUnitRanges
-function IdOffsetRange{T,I}(r::AbstractUnitRange, offset::Integer = Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
+function IdOffsetRange{T,I}(r::AbstractUnitRange, offset::Integer=Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
     rc, o = offset_coerce(I, r)
     return IdOffsetRange{T,I}(rc, convert(T, o+offset)::T)
 end
-function IdOffsetRange{T}(r::AbstractUnitRange, offset::Integer = Int8(0)) where T<:Integer
+function IdOffsetRange{T}(r::AbstractUnitRange, offset::Integer=Int8(0)) where T<:Integer
     rc = convert(AbstractUnitRange{T}, r)::AbstractUnitRange{T}
     return IdOffsetRange{T,typeof(rc)}(rc, convert(T, offset)::T)
 end
-IdOffsetRange(r::AbstractUnitRange{T}, offset::Integer = Int8(0)) where T<:Integer =
+IdOffsetRange(r::AbstractUnitRange{T}, offset::Integer=Int8(0)) where T<:Integer =
     IdOffsetRange{T,typeof(r)}(r, convert(T, offset)::T)
 
 # Coercion from other IdOffsetRanges
 IdOffsetRange{T,I}(r::IdOffsetRange{T,I}) where {T<:Integer,I<:AbstractUnitRange{T}} = r
-function IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer = Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
+function IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer=Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
     rc, offset_rc = offset_coerce(I, r.parent)
     return IdOffsetRange{T,I}(rc, convert(T, r.offset + offset + offset_rc)::T)
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -104,20 +104,20 @@ end
 _bool_check(::Type, r, offset) = nothing
 
 # Construction/coercion from arbitrary AbstractUnitRanges
-function IdOffsetRange{T,I}(r::AbstractUnitRange, offset::Integer=Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
+function IdOffsetRange{T,I}(r::AbstractUnitRange, offset::Integer = 0) where {T<:Integer,I<:AbstractUnitRange{T}}
     rc, o = offset_coerce(I, r)
     return IdOffsetRange{T,I}(rc, convert(T, o+offset)::T)
 end
-function IdOffsetRange{T}(r::AbstractUnitRange, offset::Integer=Int8(0)) where T<:Integer
+function IdOffsetRange{T}(r::AbstractUnitRange, offset::Integer = 0) where T<:Integer
     rc = convert(AbstractUnitRange{T}, r)::AbstractUnitRange{T}
     return IdOffsetRange{T,typeof(rc)}(rc, convert(T, offset)::T)
 end
-IdOffsetRange(r::AbstractUnitRange{T}, offset::Integer=Int8(0)) where T<:Integer =
+IdOffsetRange(r::AbstractUnitRange{T}, offset::Integer = 0) where T<:Integer =
     IdOffsetRange{T,typeof(r)}(r, convert(T, offset)::T)
 
 # Coercion from other IdOffsetRanges
 IdOffsetRange{T,I}(r::IdOffsetRange{T,I}) where {T<:Integer,I<:AbstractUnitRange{T}} = r
-function IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer=Int8(0)) where {T<:Integer,I<:AbstractUnitRange{T}}
+function IdOffsetRange{T,I}(r::IdOffsetRange, offset::Integer = 0) where {T<:Integer,I<:AbstractUnitRange{T}}
     rc, offset_rc = offset_coerce(I, r.parent)
     return IdOffsetRange{T,I}(rc, convert(T, r.offset + offset + offset_rc)::T)
 end
@@ -134,7 +134,7 @@ _subtractindexoffset(values, indices, offset) = _subtractoffset(values, offset)
 function IdOffsetRange(; values::AbstractUnitRange{<:Integer}, indices::AbstractUnitRange{<:Integer})
     length(values) == length(indices) || throw(ArgumentError("values and indices must have the same length"))
     values_nooffset = no_offset_view(values)
-    offset = first(indices) - Int8(1)
+    offset = first(indices) - 1
     values_minus_offset = _subtractindexoffset(values_nooffset, indices, offset)
     return IdOffsetRange(values_minus_offset, offset)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,7 @@
 _indexoffset(r::AbstractRange) = first(r) - 1
 _indexoffset(i::Integer) = 0
 _indexlength(r::AbstractRange) = length(r)
-_indexlength(i::Integer) = i
+_indexlength(i::Integer) = Int(i)  # Convert to Int for Base compatibility (reshape, etc.)
 _indexlength(i::Colon) = Colon()
 
 # utility methods used in reshape

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -17,7 +17,10 @@ _toaxis(i) = i
 _strip_IdOffsetRange(r::IdOffsetRange) = parent(r)
 _strip_IdOffsetRange(r) = r
 
-_offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)
+_offset(axparent::AbstractUnitRange, ax::AbstractUnitRange{Int}) = first(ax) - first(axparent)
+
+# Keep the provided integer if possible
+_offset(axparent::AbstractUnitRange, ax::AbstractUnitRange{I}) where {I<:Integer} = first(ax) - convert(I, first(axparent))
 _offset(axparent::AbstractUnitRange, ::Union{Integer, Colon}) = 1 - first(axparent)
 
 _offsets(A::AbstractArray) = map(ax -> first(ax) - 1, axes(A))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,7 @@
 _indexoffset(r::AbstractRange) = first(r) - 1
 _indexoffset(i::Integer) = 0
 _indexlength(r::AbstractRange) = length(r)
-_indexlength(i::Integer) = Int(i)
+_indexlength(i::Integer) = i
 _indexlength(i::Colon) = Colon()
 
 # utility methods used in reshape

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -859,7 +859,7 @@ Base.Int(a::WeirdInteger) = a
 
         # should throw a TypeError if the offsets can not be converted to Ints
         # this test does not work anymore?
-        # @test_throws TypeError OffsetVector{Int,Vector{Int}}(zeros(Int,2), (WeirdInteger(1),))
+        @test_throws TypeError OffsetVector{Int,Vector{Int}}(zeros(Int,2), (WeirdInteger(1),))
     end
 
     @testset "custom range types" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
 @testset "Project meta quality checks" begin
     Aqua.test_all(OffsetArrays, piracies=false)
     if VERSION >= v"1.2"
-        doctest(OffsetArrays, manual = false)
+        doctest(OffsetArrays, manual=false)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -459,9 +459,10 @@ Base.Int(a::WeirdInteger) = a
         ]
 
         offsets = size.(one_based_axes[1], 1)
-        offsets_big = map(big, offsets)
+        # Test with different integer offset types (Int8, Int16, Int32, Int64, Int128, BigInt)
+        offsets_all = [map(T, offsets) for T in (Int8, Int16, Int32, Int64, Int128, BigInt)]
 
-        for inds in Any[offsets, offsets_big, one_based_axes...]
+        for inds in Any[offsets_all..., one_based_axes...]
             # test indices API
             a = OffsetVector{Float64}(undef, inds)
             @test eltype(a) === Float64
@@ -489,7 +490,7 @@ Base.Int(a::WeirdInteger) = a
         end
 
         # nested OffsetVectors
-        for inds in Any[offsets, offsets_big]
+        for inds in offsets_all
             a = OffsetVector{Float64}(undef, inds)
             b = OffsetVector(a, inds); b2 = OffsetVector(a, inds...);
             @test eltype(b) === eltype(b2) === Float64
@@ -653,9 +654,10 @@ Base.Int(a::WeirdInteger) = a
         ]
 
         offsets = size.(one_based_axes[1], 1)
-        offsets_big = map(big, offsets)
+        # Test with different integer offset types (Int8, Int16, Int32, Int64, Int128, BigInt)
+        offsets_all = [map(T, offsets) for T in (Int8, Int16, Int32, Int64, Int128, BigInt)]
 
-        for inds in Any[offsets, offsets_big, one_based_axes...]
+        for inds in Any[offsets_all..., one_based_axes...]
             # test API
             a = OffsetMatrix{Float64}(undef, inds)
             ax = (IdOffsetRange(Base.OneTo(4), 0), IdOffsetRange(Base.OneTo(3), 0))
@@ -682,7 +684,7 @@ Base.Int(a::WeirdInteger) = a
         @test_throws Union{ArgumentError, ErrorException} OffsetMatrix{Float64}(undef, 2, -2) # only positive numbers works
 
         # nested OffsetMatrices
-        for inds in Any[offsets, offsets_big]
+        for inds in offsets_all
             a = OffsetMatrix{Float64}(undef, inds)
             b = OffsetMatrix(a, inds); b2 = OffsetMatrix(a, inds...);
             @test eltype(b) === eltype(b2) === Float64
@@ -857,9 +859,9 @@ Base.Int(a::WeirdInteger) = a
         # ndim of an OffsetArray should match that of the parent
         @test_throws TypeError OffsetArray{Float64,3,Matrix{Float64}}
 
-        # should throw a TypeError if the offsets can not be converted to Ints
-        # this test does not work anymore?
-        @test_throws TypeError OffsetVector{Int,Vector{Int}}(zeros(Int,2), (WeirdInteger(1),))
+        # should throw an error if the offset type doesn't support proper arithmetic operations
+        # (previously threw TypeError when converting to Int, now throws during overflow_check)
+        @test_throws Exception OffsetVector{Int,Vector{Int}}(zeros(Int,2), (WeirdInteger(1),))
     end
 
     @testset "custom range types" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -435,6 +435,10 @@ Base.Int(a::WeirdInteger) = a
         @test a === OffsetArray(a, ())
         @test_throws ArgumentError OffsetArray(a, 0)
         @test_throws ArgumentError OffsetArray(a0, 0)
+        # Test 0-dimensional array with explicit type parameters (coverage for 0-dim constructors)
+        b = OffsetArray{Int, 0, typeof(a0)}(a0, ())
+        @test b[] == 3
+        @test axes(b) == ()
     end
 
     @testset "OffsetVector" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,12 +45,12 @@ function same_value(r1, r2)
     return true
 end
 
-# @testset "Project meta quality checks" begin
-#     Aqua.test_all(OffsetArrays, piracies=false)
-#     if VERSION >= v"1.2"
-#         doctest(OffsetArrays, manual=false)
-#     end
-# end
+@testset "Project meta quality checks" begin
+    Aqua.test_all(OffsetArrays, piracies=false)
+    if VERSION >= v"1.2"
+        doctest(OffsetArrays, manual=false)
+    end
+end
 
 @testset "IdOffsetRange" begin
 
@@ -1895,12 +1895,12 @@ Base.reshape(M::MyBigFill, ind::Tuple{}) = MyBigFill(M.val, ind)
     Arsc[1,1] = 5
     @test first(A) == 5
 
-    # @testset "issue #235" begin
-    #     Vec64  = zeros(6)
-    #     ind_a_64 = 3
-    #     ind_a_32 =Int32.(ind_a_64)
-    #     @test reshape(Vec64, ind_a_32, :) == reshape(Vec64, ind_a_64, :)
-    # end
+    @testset "issue #235" begin
+        Vec64  = zeros(6)
+        ind_a_64 = 3
+        ind_a_32 =Int32.(ind_a_64)
+        @test reshape(Vec64, ind_a_32, :) == reshape(Vec64, ind_a_64, :)
+    end
 
     R = reshape(zeros(6), 2, :)
     @test R isa Matrix


### PR DESCRIPTION
This PR is trying to solve #370. This is just an initial proposal, but I guess there is a lot of work to do still.
I have noticed that
```julia
julia> BigInt(1) !== BigInt(1)
true
```
so I had to manually change some tests when the offsets are `BigInt`s

Any suggestion or comment is more than welcome as I am not very sure about downstream implications of this PR