### PR TITLE
Implement BroadcastStyle using Adapt's unwrap_type

### DIFF
--- a/ext/OffsetArraysAdaptExt.jl
+++ b/ext/OffsetArraysAdaptExt.jl
@@ -13,7 +13,7 @@ Adapt.adapt_structure(to, O::OffsetArray) = OffsetArrays.parent_call(x -> Adapt.
     Adapt.parent_type(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
     Adapt.unwrap_type(W::Type{<:OffsetArray}) = unwrap_type(parent_type(W))
 
-    Base.Broadcast.BroadcastStyle(W::Type{<:OffsetArray}) = BroadcastStyle(unwrap_type(W))
+    Base.Broadcast.BroadcastStyle(W::Type{<:OffsetArray}) = Base.Broadcast.BroadcastStyle(unwrap_type(W))
 end
 
 end

--- a/ext/OffsetArraysAdaptExt.jl
+++ b/ext/OffsetArraysAdaptExt.jl
@@ -12,6 +12,8 @@ Adapt.adapt_structure(to, O::OffsetArray) = OffsetArrays.parent_call(x -> Adapt.
     # To support Adapt 3.0 which doesn't have parent_type defined
     Adapt.parent_type(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA
     Adapt.unwrap_type(W::Type{<:OffsetArray}) = unwrap_type(parent_type(W))
+
+    Base.Broadcast.BroadcastStyle(W::Type{<:OffsetArray}) = BroadcastStyle(unwrap_type(W))
 end
 
 end

--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -280,12 +280,6 @@ parenttype(A::OffsetArray) = parenttype(typeof(A))
 
 Base.parent(A::OffsetArray) = A.parent
 
-# TODO: Ideally we would delegate to the parent's broadcasting implementation, but that
-#       is currently broken in sufficiently many implementation, namely RecursiveArrayTools, DistributedArrays
-#       and StaticArrays, that it will take concentrated effort to get this working across the ecosystem.
-#       The goal would be to have `OffsetArray(CuArray) .+ 1 == OffsetArray{CuArray}`.
-# Base.Broadcast.BroadcastStyle(::Type{<:OffsetArray{<:Any, <:Any, AA}}) where AA = Base.Broadcast.BroadcastStyle(AA)
-
 @inline Base.size(A::OffsetArray) = size(parent(A))
 # specializing length isn't necessary, as length(A) = prod(size(A)),
 # but specializing length enables constant-propagation for statically sized arrays


### PR DESCRIPTION
The goal here is to support GPU accelerated broadcasts of OffsetArrays.
We tried this before and @timholy had some concerns, but with `unwrap_type` we should
be able to implement this throughout the ecosystem correctly.

One issue for me is that it changes the behavior of a core functionailty depending on the fact if Adapt.jl
is loaded or not, I would advocate to turn Adapt.jl into a proper dependency again.

### TODO
- [ ] Decide if Adapt.jl should become a principal dependency again
- [ ] Implement tests (maybe with OpenCL.jl since that doesn't require a GPU)

