### PR TITLE
Dispatch on `AbstractOneTo` when it is available

### DIFF
--- a/src/OffsetArrays.jl
+++ b/src/OffsetArrays.jl
@@ -11,6 +11,12 @@ export OffsetArray, OffsetMatrix, OffsetVector
 
 const IIUR = IdentityUnitRange{<:AbstractUnitRange{<:Integer}}
 
+if VERSION >= v"1.13.0-DEV.876"
+    const OneTo{T<:Integer} = Base.AbstractOneTo{T}
+else
+    const OneTo{T<:Integer} = Base.OneTo{T}
+end
+
 include("axes.jl")
 include("utils.jl")
 include("origin.jl")
@@ -552,7 +558,7 @@ for OR in [:IIUR, :IdOffsetRange]
         _boundscheck_index_retaining_axes(r, s)
     end
 end
-Base.getindex(r::Base.OneTo, s::IdOffsetRange) = _boundscheck_index_retaining_axes(r, s)
+Base.getindex(r::OneTo, s::IdOffsetRange) = _boundscheck_index_retaining_axes(r, s)
 if VERSION < v"1.7.0-beta2"
     Base.getindex(r::Base.OneTo, s::IIUR) = _boundscheck_index_retaining_axes(r, s)
 end
@@ -694,11 +700,11 @@ no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
 if isdefined(Base, :IdentityUnitRange)
     # valid only if Slice is distinguished from IdentityUnitRange
     _onebasedslice(S::Base.Slice) = Base.Slice(Base.OneTo(length(S)))
-    _onebasedslice(S::Base.Slice{<:Base.OneTo}) = S
+    _onebasedslice(S::Base.Slice{<:OneTo}) = S
     _onebasedslice(S) = S
     _isoffsetslice(::Any) = false
     _isoffsetslice(::Base.Slice) = true
-    _isoffsetslice(::Base.Slice{<:Base.OneTo}) = false
+    _isoffsetslice(::Base.Slice{<:OneTo}) = false
     function no_offset_view(S::SubArray)
         #= If a view contains an offset Slice axis,
         i.e. it is a view of an offset array along the offset axis,
@@ -743,7 +749,7 @@ no_offset_view(a::Array) = a
 no_offset_view(i::Number) = i
 no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)
 _no_offset_view(::Tuple{}, A::AbstractArray{T,0}) where T = A
-_no_offset_view(::Tuple{Base.OneTo, Vararg{Base.OneTo}}, A::AbstractArray) = A
+_no_offset_view(::Tuple{OneTo, Vararg{OneTo}}, A::AbstractArray) = A
 _no_offset_view(::Any, A::AbstractArray) = _no_offset_view(A)
 _no_offset_view(A::AbstractArray) = OffsetArray(A, Origin(1))
 _no_offset_view(A::AbstractUnitRange) = UnitRange(A)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -129,7 +129,7 @@ IdOffsetRange(r::IdOffsetRange) = r
 
 # Constructor to make `show` round-trippable
 # try to preserve typeof(values) if the indices are known to be 1-based
-_subtractindexoffset(values, indices::Union{Base.OneTo, IdentityUnitRange{<:Base.OneTo}}, offset) = values
+_subtractindexoffset(values, indices::Union{OneTo, IdentityUnitRange{<:OneTo}}, offset) = values
 _subtractindexoffset(values, indices, offset) = _subtractoffset(values, offset)
 function IdOffsetRange(; values::AbstractUnitRange{<:Integer}, indices::AbstractUnitRange{<:Integer})
     length(values) == length(indices) || throw(ArgumentError("values and indices must have the same length"))
@@ -157,7 +157,7 @@ end
 # Base.convert(::Type{IdOffsetRange{T,I}}, r::AbstractUnitRange) where {T<:Integer,I<:AbstractUnitRange{T}} =
 #     IdOffsetRange{T,I}(convert(I, r), 0)
 
-offset_coerce(::Type{Base.OneTo{T}}, r::Base.OneTo) where T<:Integer = convert(Base.OneTo{T}, r), 0
+offset_coerce(::Type{Base.OneTo{T}}, r::OneTo) where T<:Integer = convert(Base.OneTo{T}, r), 0
 function offset_coerce(::Type{Base.OneTo{T}}, r::AbstractUnitRange) where T<:Integer
     o = first(r) - 1
     return Base.OneTo{T}(last(r) - o), o

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -86,9 +86,9 @@ function _checkindices(N::Integer, indices, label)
 end
 
 @inline _indexedby(r::AbstractVector, ax::Tuple{Any}) = _indexedby(r, ax[1])
-@inline _indexedby(r::AbstractUnitRange{<:Integer}, ::Base.OneTo) = no_offset_view(r)
-@inline _indexedby(r::AbstractUnitRange{Bool}, ::Base.OneTo) = no_offset_view(r)
-@inline _indexedby(r::AbstractVector, ::Base.OneTo) = no_offset_view(r)
+@inline _indexedby(r::AbstractUnitRange{<:Integer}, ::OneTo) = no_offset_view(r)
+@inline _indexedby(r::AbstractUnitRange{Bool}, ::OneTo) = no_offset_view(r)
+@inline _indexedby(r::AbstractVector, ::OneTo) = no_offset_view(r)
 @inline function _indexedby(r::AbstractUnitRange{<:Integer}, ax::AbstractUnitRange)
 	of = convert(eltype(r), first(ax) - 1)
 	IdOffsetRange(_subtractoffset(r, of), of)
@@ -120,5 +120,5 @@ _of_eltype(T, M::AbstractArray) = map(T, M)
 _filterreshapeinds(t::Tuple{AbstractUnitRange, Vararg{Any}}) = t
 _filterreshapeinds(t::Tuple) = _filterreshapeinds(tail(t))
 _filterreshapeinds(t::Tuple{}) = t
-_popreshape(A::AbstractArray, ax::Tuple{Vararg{Base.OneTo}}, inds::Tuple{}) = no_offset_view(A)
+_popreshape(A::AbstractArray, ax::Tuple{Vararg{OneTo}}, inds::Tuple{}) = no_offset_view(A)
 _popreshape(A::AbstractArray, ax, inds) = A


### PR DESCRIPTION
Since `Base` has added `AbstractOneTo` in v1.13, we may distinguish offset arrays from the supertype instead of from `Base.OneTo`. This way, arrays with `AbstractOneTo` axes, such as `StaticArray`s, will also be treated as one-based by `OffsetArrays`.

Tests still to be added.