### PR TITLE
docs: Update to a new version of documenter and skip develop

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,9 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
+[sources]
+OffsetArrays = { path = ".." }
+
 [compat]
-Documenter = "0.27"
+Documenter = "^1"
 JSON = "0.21"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -11,3 +11,8 @@ OffsetArrays.AxisConversionStyle
 OffsetArrays.center
 OffsetArrays.centered
 ```
+
+# Internals
+```@docs
+Base.unsafe_wrap(::OffsetArrays.OffsetArrayUnion{T,N}, ::Ptr{T}, ::NTuple{N, OffsetArrays.OffsetAxisKnownLength}) where {T,N}
+```

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -22,7 +22,7 @@ julia> ro[-1]
 -1
 
 julia> ro[3]
-ERROR: BoundsError: attempt to access 3-element $(IdOffsetRange{Int, UnitRange{Int}}) with indices -1:1 at index [3]
+ERROR: BoundsError: attempt to access 3-element $(nameof(IdOffsetRange)){$(nameof(Int)), UnitRange{$(nameof(Int))}} with indices -1:1 at index [3]
 ```
 
 If the range doesn't start at 1, the values may be different from the indices:
@@ -37,7 +37,7 @@ julia> ro[-1]
 9
 
 julia> ro[3]
-ERROR: BoundsError: attempt to access 3-element $(IdOffsetRange{Int, UnitRange{Int}}) with indices -1:1 at index [3]
+ERROR: BoundsError: attempt to access 3-element $(nameof(IdOffsetRange)){$(nameof(Int)), UnitRange{$(nameof(Int))}} with indices -1:1 at index [3]
 ```
 
 # Extended help


### PR DESCRIPTION
- New documenter generates `objects.inv` which allows for external
  references
- Adding the `sources` section in the `Project.toml` ensures that the
  documentation is always built for the current developed version and
  not for the stable version fetched from the registry even if `develop`
  is skipped in the generation process which ensures that no head
  scratching issues happen during the development.
